### PR TITLE
Close connections before deleting database

### DIFF
--- a/brunnhilde.py
+++ b/brunnhilde.py
@@ -884,13 +884,13 @@ def main():
     # remove temp html file
     os.remove(temp_html)
 
-    # remove sqlite db unless user selected to retain
-    if not args.keepsqlite:
-        os.remove(os.path.join(report_dir, 'siegfried.sqlite'))
-
     # close database connections
     cursor.close()
     conn.close()
+
+    # remove sqlite db unless user selected to retain
+    if not args.keepsqlite:
+        os.remove(os.path.join(report_dir, 'siegfried.sqlite'))
 
     print("\nBrunnhilde characterization complete. Reports in %s." % report_dir)
 


### PR DESCRIPTION
Was getting this error on windows machine using command prompt:

```
Siegfried scan complete. Processing results.
Traceback (most recent call last):
  File "C:\Users\sonoe\AppData\Local\Programs\Python\Python37\Scripts\brunnhilde.py", line 898, in <module>
    main()
  File "C:\Users\sonoe\AppData\Local\Programs\Python\Python37\Scripts\brunnhilde.py", line 889, in main
    os.remove(os.path.join(report_dir, 'siegfried.sqlite'))
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\sonoe\\Desktop\\reports\\128\\siegfried.sqlite'
```
Closing connection before deleting the database resolved the issue. 