### PR TITLE
Update README.md - removes reference to installing requests module

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,6 @@ For Brunnhilde to report on any directory of content, the following must be inst
 
 * Python (2.7 or 3.4+; Python 3 is recommended)
 * [Siegfried](http://www.itforarchivists.com/siegfried): Brunnhilde is now compatible with all version of Siegfried, including 1.6+. It does not support MIME-Info or FDD signatures: for Brunnhilde to work, Siegfried must be using the PRONOM signature file only. If you have been using MIME-Info or FDD signatures as a replacement for or alongside PRONOM with Siegfried 1.5/1.6 on your machine, entering `roy build -multi 0` in the terminal should return you to Siegfried's default PRONOM-only identification mode and allow Brunnhilde to work properly.  
-* [requests Python module](https://pypi.org/project/requests/): For downloading CSS and JS files for HTML report from this repository. This should be automatically installed as a dependency when Brunnhilde is installed via pip.
 
 #### Additional dependencies (for full functionality in Linux and macOS)
 


### PR DESCRIPTION
I noticed that requests is no longer needed. I investigated this while making sure that I can run brunnhilde without an internet connection, and thankfully pip doesn't pull any dependencies anymore!